### PR TITLE
Support for :preloads

### DIFF
--- a/src/powerlaces/boot_cljs_devtools.clj
+++ b/src/powerlaces/boot_cljs_devtools.clj
@@ -8,21 +8,19 @@
             [dirac.agent.config :as    dirac-conf]))
 
 (def ^:private deps
-  '[[binaryage/devtools "0.7.0" :scope "test"]
-    [binaryage/dirac    "0.6.0" :scope "test"]])
+  '[[binaryage/devtools "0.8.0" :scope "test"]
+    [binaryage/dirac    "0.6.3" :scope "test"]])
 
-(defn- add-init! [in-file out-file]
-  (let [ns ['devtools.core 'dirac.runtime]
-        init ['devtools.core/install! 'dirac.runtime/install!]
+(defn- add-preloads! [in-file out-file]
+  (let [preloads ['devtools.preload 'powerlaces.boot-cljs-devtools.dirac.preload]
         spec (-> in-file slurp read-string)]
     (when (not= :nodejs (-> spec :compiler-options :target))
       (util/info
-       "Adding :require %s and :init-fns %s to %s...\n"
-       ns init (.getName in-file))
+       "Adding :preloads %s to %s...\n"
+       preloads (.getName in-file))
       (io/make-parents out-file)
       (-> spec
-          (update-in [:require] into ns)
-          (update-in [:init-fns] #(into init %))
+          (update-in [:preloads] #(into preloads %))
           pr-str
           ((partial spit out-file))))))
 
@@ -80,12 +78,12 @@
                in-file (boot/tmp-file f)
                out-file (io/file tmp path)]
            (io/make-parents out-file)
-           (add-init! in-file out-file)))
+           (add-preloads! in-file out-file)))
        (reset! prev fileset)
        (-> fileset
            (boot/add-resource tmp)
            (boot/commit!))))))
 
 (comment
-  (require '[jupl.boot-cljs-devtools :as dvt])
+  (require '[powerlaces.boot-cljs-devtools :as dvt])
   (boot (dvt/cljs-devtools)))

--- a/src/powerlaces/boot_cljs_devtools/dirac/preload.cljs
+++ b/src/powerlaces/boot_cljs_devtools/dirac/preload.cljs
@@ -1,0 +1,4 @@
+(ns powerlaces.boot-cljs-devtools.dirac.preload
+  (:require [dirac.runtime]))
+
+(dirac.runtime/install!)


### PR DESCRIPTION
Changes `:init-fns` based installation of Dirac and DevTools to use [:preloads](https://github.com/binaryage/cljs-devtools/blob/master/docs/installation.md#install-it-via-preloads) instead.

Includes a stub ns `powerlaces.boot-cljs-devtools.dirac.preload` for Dirac as I couldn't find a Dirac equivalent of `devtools.preload`.
