### PR TITLE
Fix incorrect location of :preloads config

### DIFF
--- a/src/powerlaces/boot_cljs_devtools.clj
+++ b/src/powerlaces/boot_cljs_devtools.clj
@@ -18,7 +18,7 @@
        preloads (.getName in-file))
       (io/make-parents out-file)
       (-> spec
-          (update-in [:preloads] #(into preloads %))
+          (update-in [:compiler-options :preloads] #(into preloads %))
           pr-str
           ((partial spit out-file))))))
 


### PR DESCRIPTION
 Sorry I had tested a stale jar with ​_both_​ `:require` and `:preloads`, where `:preloads` was a no-op because its actually supposed to be in `:compiler-options`. I guess it was only working at all because of the `:require`. I now have devtools and dirac both working with `:compiler-options :preloads` ​_only_​ (no `:require`). 
