### PR TITLE
Support for Dirac 0.7.x

### DIFF
--- a/README.org
+++ b/README.org
@@ -8,8 +8,8 @@ Latest version:
 
 In order to install it, add the following to your =build.boot= dependencies:
 #+BEGIN_SRC clojure
-[binaryage/devtools      "0.8.0" :scope "test"]
-[binaryage/dirac         "0.6.3" :scope "test"]
+[binaryage/devtools      "0.8.2" :scope "test"]
+[binaryage/dirac         "0.7.1" :scope "test"]
 [powerlaces/boot-cljs-devtools "0.X.X" :scope "test"]
 #+END_SRC
 In addition require the task, specifically =cljs-devtools=.

--- a/src/powerlaces/boot_cljs_devtools.clj
+++ b/src/powerlaces/boot_cljs_devtools.clj
@@ -10,7 +10,7 @@
 (def ^:private deps '#{binaryage/devtools binaryage/dirac})
 
 (defn- add-preloads! [in-file out-file]
-  (let [preloads ['devtools.preload 'powerlaces.boot-cljs-devtools.preload]
+  (let [preloads ['devtools.preload 'dirac.runtime.preload]
         spec (-> in-file slurp read-string)]
     (when (not= :nodejs (-> spec :compiler-options :target))
       (util/info
@@ -49,7 +49,7 @@
 (def nrepl-defaults
   {:port 8230
    :server true
-   :middleware ['dirac.nrepl.middleware/dirac-repl]})
+   :middleware ['dirac.nrepl/middleware]})
 
 (boot/deftask cljs-devtools
   "Add Chrome Devtool enhancements for ClojureScript development."

--- a/src/powerlaces/boot_cljs_devtools/preload.cljs
+++ b/src/powerlaces/boot_cljs_devtools/preload.cljs
@@ -1,4 +1,0 @@
-(ns powerlaces.boot-cljs-devtools.preload
-  (:require [dirac.runtime]))
-
-(dirac.runtime/install!)


### PR DESCRIPTION
Without this 0.7.x Dirac releases throw an exception on boot startup. Also migrated to Dirac's own perloads ns which has the added benefit of supporting compiler external config so our own preload ns stub for Dirac is not needed anymore.
